### PR TITLE
Add deployment config files for monolith

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Telegram bot token
+BOT_TOKEN=replace_me
+# OpenAI API key
+OPENAI_API_KEY=replace_me
+# Optional model override
+OPENAI_MODEL=gpt-4.1-mini
+# Optional existing assistant ID
+ASSISTANT_ID=
+# SQLite database path
+ST_DB=supertime.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0.0
+python-telegram-bot>=20.0


### PR DESCRIPTION
## Summary
- add Python dependencies for OpenAI Assistants API bot
- provide sample environment variable file for Railway deployment

## Testing
- `python -m py_compile monolith.py`
- `pip install openai python-telegram-bot` *(failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a05e2b83bc8329a05aa88c2f9b2e6b