### PR TITLE
Handle REPLY instructions in hero snapshots

### DIFF
--- a/heroes/andrew.prompt
+++ b/heroes/andrew.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Andrew
 ROLE: Nearly mute witness.
 

--- a/heroes/dubrovsky.prompt
+++ b/heroes/dubrovsky.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Aleksei Dubrovsky
 ROLE: Glitch-aphorist; absurd cut; fourth-wall echo.
 

--- a/heroes/jan.prompt
+++ b/heroes/jan.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Jan
 ROLE: Gentle giant; physical strength; absolute loyalty.
 

--- a/heroes/judas.prompt
+++ b/heroes/judas.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Judas
 ROLE: Razor-edged narrator; painfully lucid; black humor; haunted by Mary; capable of breaking the fourth wall when the chapter allows.
 

--- a/heroes/leo.prompt
+++ b/heroes/leo.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Leo
 ROLE: Frenzied artist; sketches faces before they vanish; loves full-bodied beauty.
 

--- a/heroes/luke.prompt
+++ b/heroes/luke.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Luke
 ROLE: Compassionate clinician; notes wounds and meanings.
 

--- a/heroes/mark.prompt
+++ b/heroes/mark.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Mark
 ROLE: Urgency; action over reflection.
 

--- a/heroes/mary.prompt
+++ b/heroes/mary.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Mary
 ROLE: Quiet gravity; serves without being asked; damaged comprehension.
 

--- a/heroes/matthew.prompt
+++ b/heroes/matthew.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Matthew
 ROLE: Scribe’s memory; lists, tallies, receipts.
 

--- a/heroes/peter.prompt
+++ b/heroes/peter.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Peter
 ROLE: Acid diva; bravado, vanity, cigarette ash; jealousy toward Mary.
 

--- a/heroes/theodore.prompt
+++ b/heroes/theodore.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Theodore
 ROLE: Ghostlike writer from the future; stammered "-s"; papirosa smoke; dissolves under stress.
 

--- a/heroes/thomas.prompt
+++ b/heroes/thomas.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Thomas
 ROLE: Knife-in-coat skeptic; laughs at piety.
 

--- a/heroes/yakov.prompt
+++ b/heroes/yakov.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Yakov
 ROLE: Order-obsessed servant; grumbling loyalty; envy under rules.
 

--- a/heroes/yeshu.prompt
+++ b/heroes/yeshu.prompt
@@ -1,3 +1,4 @@
+# NOTE: REPLY section guides final message and is appended to persona snapshot.
 NAME: Yeshu (Yeshua)
 ROLE: Teacher whose slow warmth snaps into piercing questions; sad under laughter.
 

--- a/monolith.py
+++ b/monolith.py
@@ -310,6 +310,7 @@ class Hero:
         self.name = name
         self.sections = sections
         self.raw_text = raw_text
+        self.reply: str = sections.get("REPLY", "")
         self.ctx: str = ""
 
     def load_chapter_context(self, md_text: str):
@@ -425,6 +426,8 @@ def build_personas_snapshot(responders: list[str]) -> str:
         hero = HEROES.get(n)
         if hero:
             snippet = hero.raw_text[:600]
+            if hero.reply:
+                snippet += f"\n[REPLY]: {hero.reply}"
             if hero.ctx:
                 snippet += f"\n[Scene]: {hero.ctx[:200]}"
             lines.append(f"- {n}:\n{snippet}")


### PR DESCRIPTION
## Summary
- Track REPLY instructions for each Hero and include them when building persona snapshots
- Document REPLY's impact in every hero prompt file

## Testing
- `pytest -q`
- `python -m py_compile monolith.py`
- `flake8 monolith.py` *(fails: command not found; attempted `pip install flake8` but proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a0681b6be08329aa385616bda98e7b