### PR TITLE
Reset pending Telegram long polls before starting

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -15,7 +15,7 @@ import hashlib
 from pathlib import Path
 from collections import defaultdict, deque
 
-from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, Bot
 from telegram.constants import ParseMode
 from telegram.ext import (
     Application, CommandHandler, CallbackQueryHandler,
@@ -682,7 +682,17 @@ async def on_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
 # =========================
 # Main
 # =========================
+async def reset_updates():
+    """Terminate any other long-polling sessions for this bot."""
+    bot = Bot(token=TELEGRAM_TOKEN)
+    try:
+        await bot.get_updates()
+    finally:
+        await bot.close()
+
+
 def main():
+    asyncio.run(reset_updates())
     app = Application.builder().token(TELEGRAM_TOKEN).build()
     app.add_handler(CommandHandler("start", start))
     app.add_handler(CommandHandler("help", help_cmd))


### PR DESCRIPTION
## Summary
- terminate any existing getUpdates session before running the bot to avoid 409 conflicts

## Testing
- `python -m py_compile monolith.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f77f1dbc8329a8ae371af23e9c95