### PR TITLE
Initialize event loop before running telegram bot

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -696,7 +696,9 @@ async def reset_updates():
 
 
 def main():
-    asyncio.run(reset_updates())
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(reset_updates())
     app = Application.builder().token(TELEGRAM_TOKEN).build()
     app.add_handler(CommandHandler("start", start))
     app.add_handler(CommandHandler("help", help_cmd))


### PR DESCRIPTION
## Summary
- Ensure a running asyncio event loop is available before starting the Telegram bot

## Testing
- `python -m py_compile monolith.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a104b293c8832984fb24b45c878621