### PR TITLE
reset updates by deleting webhook before polling

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -689,6 +689,7 @@ async def reset_updates():
     bot = Bot(token=TELEGRAM_TOKEN)
     try:
         with contextlib.suppress(RetryAfter):
+            await bot.delete_webhook(drop_pending_updates=True)
             await bot.get_updates()
     finally:
         with contextlib.suppress(RetryAfter):


### PR DESCRIPTION
## Summary
- avoid Telegram `getUpdates` conflict by removing any active webhook before polling for updates

## Testing
- `ruff check monolith.py` *(fails: unused imports, style errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a106eca05883299d2002c32394dfb4