### PR TITLE
Handle missing PTB JobQueue

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -839,7 +839,10 @@ def main():
     app.add_handler(CommandHandler("reload_heroes", reload_heroes_cmd))  # [HEROES]
     app.add_handler(CallbackQueryHandler(on_click))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, on_text))
-    app.job_queue.run_repeating(periodic_cleanup, interval=3600, first=3600)
+    if app.job_queue:
+        app.job_queue.run_repeating(periodic_cleanup, interval=3600, first=3600)
+    else:
+        print("Job queue disabled; periodic cleanup skipped.")
     loop.run_until_complete(app.bot.set_my_commands([("back", "Return to previous menu")]))
     loop.run_until_complete(app.bot.set_chat_menu_button(menu_button=MenuButtonCommands()))
     print("SUPPERTIME (Assistants API) — ready.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 openai>=1.0.0
-python-telegram-bot>=20.0
+python-telegram-bot[job-queue]>=20.0


### PR DESCRIPTION
## Summary
- Install python-telegram-bot with job-queue extras to ensure JobQueue support
- Skip periodic cleanup when JobQueue is unavailable

## Testing
- `pytest`
- `ruff check monolith.py | tail -n 20` *(fails: Found 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1232164488329912adcc3aec2308c