### PR TITLE
Centralize environment configuration with Settings

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+from dotenv import load_dotenv
+
+# Load variables from a .env file if present
+load_dotenv()
+
+
+@dataclass
+class Settings:
+    """Application configuration loaded from environment variables."""
+
+    openai_model: str = os.getenv("OPENAI_MODEL", "gpt-4.1")
+    openai_temperature: float = float(os.getenv("OPENAI_TEMPERATURE", "1.2"))
+    telegram_token: str | None = os.getenv("TELEGRAM_TOKEN")
+    openai_api_key: str | None = os.getenv("OPENAI_API_KEY")
+    db_path: str = os.getenv("ST_DB", "supertime.db")
+    summary_every: int = int(os.getenv("SUMMARY_EVERY", "20"))
+    assistant_id: str | None = os.getenv("ASSISTANT_ID")
+    hero_ctx_cache_dir: Path = Path(os.getenv("HERO_CTX_CACHE_DIR", ".hero_ctx_cache"))
+
+
+settings = Settings()
+
+if not settings.telegram_token:
+    raise RuntimeError("Set TELEGRAM_TOKEN env var")
+
+if not settings.openai_api_key:
+    raise RuntimeError("Set OPENAI_API_KEY env var")

--- a/monolith.py
+++ b/monolith.py
@@ -7,7 +7,6 @@
 #   OPENAI_TEMPERATURE=1.2
 #   ASSISTANT_ID=<reuse existing>
 
-import os
 import re
 import sqlite3
 import random
@@ -17,6 +16,8 @@ from pathlib import Path
 from collections import defaultdict, deque
 import contextlib
 import time
+
+from config import settings
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, Bot, MenuButtonCommands
 from telegram.constants import ParseMode
@@ -33,19 +34,19 @@ except Exception as e:
     raise RuntimeError("Install openai>=1.0:  pip install openai python-telegram-bot openai") from e
 
 # Default to the GPT-4.1 model unless overridden by env
-MODEL = os.getenv("OPENAI_MODEL", "gpt-4.1")
-TEMPERATURE = float(os.getenv("OPENAI_TEMPERATURE", "1.2"))
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+MODEL = settings.openai_model
+TEMPERATURE = settings.openai_temperature
+TELEGRAM_TOKEN = settings.telegram_token
 if not TELEGRAM_TOKEN:
     raise RuntimeError("Set TELEGRAM_TOKEN env var")
-if not os.getenv("OPENAI_API_KEY"):
+if not settings.openai_api_key:
     raise RuntimeError("Set OPENAI_API_KEY env var")
 
 # =========================
 # Storage: SQLite (threads & state)
 # =========================
-DB_PATH = os.getenv("ST_DB", "supertime.db")
-SUMMARY_EVERY = int(os.getenv("SUMMARY_EVERY", "20"))
+DB_PATH = settings.db_path
+SUMMARY_EVERY = settings.summary_every
 
 
 def get_connection():
@@ -266,7 +267,7 @@ client = OpenAI()
 ASSISTANT_ID_PATH = Path(".assistant_id")
 
 def ensure_assistant():
-    asst_id = os.getenv("ASSISTANT_ID")
+    asst_id = settings.assistant_id
     if not asst_id and ASSISTANT_ID_PATH.exists():
         asst_id = ASSISTANT_ID_PATH.read_text().strip()
 
@@ -362,7 +363,7 @@ HEROES = {}
 
 # Cache for hero context per chapter hash to avoid recomputation
 HERO_CTX_CACHE: dict[tuple[str, str], str] = {}
-HERO_CTX_CACHE_DIR = Path(os.getenv("HERO_CTX_CACHE_DIR", ".hero_ctx_cache"))
+HERO_CTX_CACHE_DIR = settings.hero_ctx_cache_dir
 HERO_CTX_CACHE_DIR.mkdir(exist_ok=True)
 
 REQUIRED_SECTIONS = ["NAME", "VOICE", "BEHAVIOR", "INIT", "REPLY"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai>=1.0.0
 python-telegram-bot[job-queue]>=20.0
 pytest
+python-dotenv


### PR DESCRIPTION
## Summary
- add `config.py` with dataclass-based `Settings` loaded via `python-dotenv`
- replace `os.getenv` calls in `monolith.py` with `Settings` properties
- declare `python-dotenv` dependency

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement python-dotenv)*
- `flake8 .` *(failed: command not found)*
- `python -m py_compile monolith.py config.py`
- `pytest` *(failed: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68a12d217ce8832995a6b5c390ec1441