### PR TITLE
feat: add typing indicator before hero lines

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -19,7 +19,7 @@ import contextlib
 import time
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, Bot, MenuButtonCommands
-from telegram.constants import ParseMode
+from telegram.constants import ParseMode, ChatAction
 from telegram.ext import (
     Application, CommandHandler, CallbackQueryHandler,
     MessageHandler, ContextTypes, filters
@@ -723,8 +723,12 @@ def parse_lines(text: str):
             yield m.group(1), m.group(2)
 
 
-async def send_hero_lines(chat, text: str):
+async def send_hero_lines(chat, text: str, context: ContextTypes.DEFAULT_TYPE):
     for name, line in parse_lines(text):
+        typing = await chat.send_message(f"{name} is typing…")
+        await context.bot.send_chat_action(chat.id, ChatAction.TYPING)
+        await asyncio.sleep(random.uniform(3, 5))
+        await typing.delete()
         await chat.send_message(f"**{name}**\n{line}", parse_mode=ParseMode.MARKDOWN)
 
 async def on_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -766,7 +770,7 @@ async def on_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
         glitch = MARKOV.glitch()
 
         await q.message.delete()
-        await send_hero_lines(q.message.chat, text)
+        await send_hero_lines(q.message.chat, text, context)
         if glitch:
             await q.message.chat.send_message(glitch, parse_mode=ParseMode.MARKDOWN)
         return
@@ -806,7 +810,7 @@ async def on_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
         text = "**Judas**: ..."
     glitch = MARKOV.glitch()
 
-    await send_hero_lines(update.message.chat, text)
+    await send_hero_lines(update.message.chat, text, context)
     if glitch:
         await update.message.chat.send_message(glitch, parse_mode=ParseMode.MARKDOWN)
     new_n = st["dialogue_n"] + 1


### PR DESCRIPTION
## Summary
- simulate typing by sending `ChatAction.TYPING` and placeholder message before hero lines
- update send_hero_lines callers to pass context

## Testing
- `flake8` *(dependency missing)*
- `TELEGRAM_TOKEN=dummy OPENAI_API_KEY=dummy pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a12e237138832983cdaae56b23e8e1