### PR TITLE
Pin OpenAI and Telegram bot versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Set the following variables before running the bot:
 
 ## Running Locally
 1. Install dependencies: `pip install -r requirements.txt`
+   - Tested with `openai==1.99.9` and `python-telegram-bot[job-queue]==22.3`
 2. Export the required environment variables
 3. Launch the bot: `python monolith.py`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai>=1.0.0
-python-telegram-bot[job-queue]>=20.0
+openai==1.99.9
+python-telegram-bot[job-queue]==22.3
 pytest
 python-dotenv


### PR DESCRIPTION
## Summary
- pin `openai` and `python-telegram-bot[job-queue]` to tested versions
- document the tested dependency versions in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a130df9eac8329be56219563e1c2c2