### PR TITLE
Remove hero name prefixes and style chat headers

### DIFF
--- a/heroes/andrew.prompt
+++ b/heroes/andrew.prompt
@@ -21,4 +21,5 @@ INIT:
 - md_text → pick 5 anchor nouns. Save as ANDREW_ANCHORS.
 
 REPLY:
-- Choose the most stabilizing word for the last exchange. OUTPUT: **Andrew**: <line>
+- Choose the most stabilizing word for the last exchange.
+- OUTPUT: <line>

--- a/heroes/dubrovsky.prompt
+++ b/heroes/dubrovsky.prompt
@@ -22,4 +22,5 @@ INIT:
 - Load aphorisms file once; keep a shuffled pool as DUB_APH.
 
 REPLY:
-- Pop next aphorism; if pool empty, repeat the first. OUTPUT: **Dubrovsky**: <line>
+- Pop next aphorism; if pool empty, repeat the first.
+- OUTPUT: <line>

--- a/heroes/jan.prompt
+++ b/heroes/jan.prompt
@@ -22,4 +22,5 @@ INIT:
 - md_text → mark threats and injuries. Save as JAN_ALERTS.
 
 REPLY:
-- Offer protection/action to last victim in buffer. OUTPUT: **Jan**: <line>
+- Offer protection/action to last victim in buffer.
+- OUTPUT: <line>

--- a/heroes/judas.prompt
+++ b/heroes/judas.prompt
@@ -29,4 +29,4 @@ INIT (load_chapter_context):
 REPLY (scene_buffer -> line):
 - Read last 3 lines, detect addressee; answer surgically.
 - Keep chapter tone from JUDAS_CTX; allow a single 4th-wall poke only if theme references reading/phone/text.
-- OUTPUT FORMAT: **Judas**: <line>
+- OUTPUT: <line>

--- a/heroes/leo.prompt
+++ b/heroes/leo.prompt
@@ -30,4 +30,5 @@ INIT (load_chapter_context):
 - Parse md_text; extract 3 strongest visual images (light, texture, pose) and 1 conflict frame. Save as LEO_VIZ.
 
 REPLY (scene_buffer -> line):
-- Glance at last speaker; reframe their claim as a visual or c
+- Glance at last speaker; reframe their claim as a visual or color cue using LEO_VIZ.
+- OUTPUT: <line>

--- a/heroes/luke.prompt
+++ b/heroes/luke.prompt
@@ -22,4 +22,5 @@ INIT:
 - md_text → find pain/mercy images. Save as LUKE_CLUES.
 
 REPLY:
-- Offer the smallest true kindness to the last hurt voice. OUTPUT: **Luke**: <line>
+- Offer the smallest true kindness to the last hurt voice.
+- OUTPUT: <line>

--- a/heroes/mark.prompt
+++ b/heroes/mark.prompt
@@ -22,4 +22,5 @@ INIT:
 - md_text → extract verbs of motion. Save as MARK_MOVE.
 
 REPLY:
-- Issue a kinetic cue to next speaker. OUTPUT: **Mark**: <line>
+- Issue a kinetic cue to next speaker.
+- OUTPUT: <line>

--- a/heroes/mary.prompt
+++ b/heroes/mary.prompt
@@ -22,4 +22,5 @@ INIT:
 - md_text → list concrete acts mentioned (wash, carry, sit, sleep). Save as MARY_ACTS.
 
 REPLY:
-- Choose the simplest verb that answers need in last 2 lines. OUTPUT: **Mary**: <line>
+- Choose the simplest verb that answers need in last 2 lines.
+- OUTPUT: <line>

--- a/heroes/matthew.prompt
+++ b/heroes/matthew.prompt
@@ -22,4 +22,5 @@ INIT:
 - md_text → list 3 recurring motifs with counts. Save as MATT_COUNTS.
 
 REPLY:
-- Summarize current tension numerically. OUTPUT: **Matthew**: <line>
+- Summarize current tension numerically.
+- OUTPUT: <line>

--- a/heroes/peter.prompt
+++ b/heroes/peter.prompt
@@ -22,4 +22,5 @@ INIT:
 - md_text → pull any props (dress, wig, mirror) and a single rumor. Save as PETER_PROPS.
 
 REPLY:
-- Target last speaker; twist their claim with vanity or envy. OUTPUT: **Peter**: <line>
+- Target last speaker; twist their claim with vanity or envy.
+- OUTPUT: <line>

--- a/heroes/theodore.prompt
+++ b/heroes/theodore.prompt
@@ -32,4 +32,4 @@ INIT (load_chapter_context):
 REPLY (scene_buffer -> line):
 - Address last speaker with a tentative question or thin confirmation using THEO_CUES.
 - If scene mentions arrest/knife/death, add a fading hint (no stage direction words).
-- OUTPUT: **Theodore**: <line>
+- OUTPUT: <line>

--- a/heroes/thomas.prompt
+++ b/heroes/thomas.prompt
@@ -22,4 +22,5 @@ INIT:
 - md_text → collect hypocrisies/contradictions. Save as THOMAS_BAITS.
 
 REPLY:
-- Hit the softest lie in last turn. OUTPUT: **Thomas**: <line>
+- Hit the softest lie in last turn.
+- OUTPUT: <line>

--- a/heroes/yakov.prompt
+++ b/heroes/yakov.prompt
@@ -22,4 +22,5 @@ INIT:
 - md_text → extract “mess” motifs (rain, floors, market rot). Save as YAKOV_TRIGGERS.
 
 REPLY:
-- Reframe conflict as cleaning task. OUTPUT: **Yakov**: <line>
+- Reframe conflict as cleaning task.
+- OUTPUT: <line>

--- a/heroes/yeshu.prompt
+++ b/heroes/yeshu.prompt
@@ -25,4 +25,4 @@ INIT:
 
 REPLY:
 - Convert conflict in last 3 lines into a question or a parable seed.
-- OUTPUT: **Yeshua**: <line>
+- OUTPUT: <line>

--- a/monolith.py
+++ b/monolith.py
@@ -791,7 +791,8 @@ async def send_hero_lines(chat, text: str, context: ContextTypes.DEFAULT_TYPE):
         await context.bot.send_chat_action(chat.id, ChatAction.TYPING)
         await asyncio.sleep(random.uniform(3, 5))
         await typing.delete()
-        await chat.send_message(f"**{name}**\n{line}", parse_mode=ParseMode.MARKDOWN)
+        header = f"**{name}**"
+        await chat.send_message(f"{header}\n{line}", parse_mode=ParseMode.MARKDOWN)
 
 async def on_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
     q = update.callback_query


### PR DESCRIPTION
## Summary
- Strip hero names from all `REPLY` sections in hero prompt files so they output only the spoken line
- Prefix each delivered line with a styled markdown header in the messaging loop

## Testing
- `python -m py_compile monolith.py config.py logger.py`
- `TELEGRAM_TOKEN=dummy OPENAI_API_KEY=dummy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a13253e47c8329958c4abb2f2c778f