### PR TITLE
Validate required env vars at bot startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 Suppertime Gospel is a Telegram Theatre that stages interactive gospel scenes using OpenAI's Assistants API.  Chapters of the narrative live in `docs/` and each character's persona lives in `heroes/`.  The bot lets you drop into any chapter and guide the conversation.
 
 ## Environment Variables
-Set the following variables before running the bot:
+Set the following variables before running the bot. They are validated at
+startup, and the bot will raise a `RuntimeError` if the required values are
+missing:
 
 - `TELEGRAM_TOKEN` – Telegram bot token (required)
 - `OPENAI_API_KEY` – OpenAI API key (required)

--- a/config.py
+++ b/config.py
@@ -25,9 +25,3 @@ class Settings:
 
 
 settings = Settings()
-
-if not settings.telegram_token:
-    raise RuntimeError("Set TELEGRAM_TOKEN env var")
-
-if not settings.openai_api_key:
-    raise RuntimeError("Set OPENAI_API_KEY env var")

--- a/monolith.py
+++ b/monolith.py
@@ -42,10 +42,6 @@ except ImportError as e:
 MODEL = settings.openai_model
 TEMPERATURE = settings.openai_temperature
 TELEGRAM_TOKEN = settings.telegram_token
-if not TELEGRAM_TOKEN:
-    raise RuntimeError("Set TELEGRAM_TOKEN env var")
-if not settings.openai_api_key:
-    raise RuntimeError("Set OPENAI_API_KEY env var")
 
 # =========================
 # Storage: SQLite (threads & state)
@@ -893,6 +889,10 @@ async def reset_updates():
 
 
 def main():
+    if not TELEGRAM_TOKEN:
+        raise RuntimeError("Set TELEGRAM_TOKEN env var")
+    if not settings.openai_api_key:
+        raise RuntimeError("Set OPENAI_API_KEY env var")
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     loop.run_until_complete(reset_updates())

--- a/tests/test_monolith.py
+++ b/tests/test_monolith.py
@@ -54,3 +54,12 @@ def test_parse_lines_block_format():
         ("Judas", "betrayal whispers"),
         ("Peter", "steadfast response"),
     ]
+
+
+def test_main_checks_env(monkeypatch):
+    import monolith
+
+    monkeypatch.setattr(monolith, "TELEGRAM_TOKEN", None)
+    monkeypatch.setattr(monolith.settings, "openai_api_key", None)
+    with pytest.raises(RuntimeError):
+        monolith.main()


### PR DESCRIPTION
## Summary
- Load environment variables in `config.py` without raising errors
- Perform required env var checks in `monolith.main()` before starting the bot
- Document and test the new startup validation behavior

## Testing
- `python -m py_compile config.py monolith.py tests/test_monolith.py`
- `pytest -q`
- ⚠️ `pip install flake8` (failed: Could not find a version that satisfies the requirement flake8)

------
https://chatgpt.com/codex/tasks/task_e_68a15b6bf8a88329a01782ac1b337ef7