### PR TITLE
Handle invalid chapter selection in on_click

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -806,6 +806,10 @@ async def on_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if q.data.startswith("ch_"):
         ch = int(q.data.split("_")[1])
         logger.info("Chat %s selected chapter %s", chat_id, ch)
+        if ch not in CHAPTERS:
+            logger.warning("Chat %s selected invalid chapter %s", chat_id, ch)
+            await q.message.chat.send_message("Unknown chapter.")
+            return
         db_set(chat_id, chapter=ch, dialogue_n=0, last_summary="")
         chapter_text = CHAPTERS[ch]
         participants = guess_participants(chapter_text)


### PR DESCRIPTION
## Summary
- Validate chapter IDs for chapter selection callbacks.
- Skip flow and notify users when invalid chapters are chosen.

## Testing
- `ruff check monolith.py` *(fails: `F401` imported but unused, `E701` multiple statements on one line, `E702` multiple statements on one line, `E401` multiple imports on one line, `F841` local variable assigned but not used)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a15cfa7e948329b8d0f853aeeced9b