### PR TITLE
Use effective_chat.id in on_click

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -790,7 +790,7 @@ async def send_hero_lines(chat, text: str, context: ContextTypes.DEFAULT_TYPE):
 async def on_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
     q = update.callback_query
     await q.answer()
-    chat_id = q.message.chat_id
+    chat_id = update.effective_chat.id
     st = db_get(chat_id)
     thread_id = ensure_thread(chat_id)
 

--- a/tests/test_bot_flow.py
+++ b/tests/test_bot_flow.py
@@ -53,7 +53,7 @@ def test_full_user_flow(monkeypatch):
     update.message.reply_text.assert_awaited()
 
     # user presses OK
-    update_ok = SimpleNamespace(callback_query=make_callback_query(chat_id, chat, "ok"))
+    update_ok = SimpleNamespace(callback_query=make_callback_query(chat_id, chat, "ok"), effective_chat=chat)
     asyncio.run(monolith.on_click(update_ok, context))
     update_ok.callback_query.edit_message_text.assert_awaited()
     state = monolith.db_get(chat_id)
@@ -62,7 +62,7 @@ def test_full_user_flow(monkeypatch):
     # user selects chapter 1
     chapter_text = monolith.CHAPTERS[1]
     mock_load = monolith.load_chapter_context_all
-    update_ch = SimpleNamespace(callback_query=make_callback_query(chat_id, chat, "ch_1"))
+    update_ch = SimpleNamespace(callback_query=make_callback_query(chat_id, chat, "ch_1"), effective_chat=chat)
     asyncio.run(monolith.on_click(update_ch, context))
     assert mock_load.awaited
     called_text = mock_load.await_args.args[0]
@@ -83,7 +83,7 @@ def test_full_user_flow(monkeypatch):
     update2 = SimpleNamespace(message=make_message(chat), effective_chat=chat)
     asyncio.run(monolith.start(update2, context))
     update2.message.reply_text.assert_awaited()
-    update_ok2 = SimpleNamespace(callback_query=make_callback_query(chat_id, chat, "ok"))
+    update_ok2 = SimpleNamespace(callback_query=make_callback_query(chat_id, chat, "ok"), effective_chat=chat)
     asyncio.run(monolith.on_click(update_ok2, context))
     update_ok2.callback_query.edit_message_text.assert_awaited()
 


### PR DESCRIPTION
## Summary
- use `update.effective_chat.id` to determine chat
- adjust tests for callback queries

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a16249db50832980381ba3b909a46e