### PR TITLE
Refine chapter selection menu and command descriptions

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -735,7 +735,7 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
 async def menu_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await update.message.reply_text("Choose a chapter:", reply_markup=chapters_menu())
+    await update.message.reply_text("\u200b", reply_markup=chapters_menu())
 
 async def reload_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     n = reload_chapters()
@@ -800,7 +800,7 @@ async def on_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if q.data == "ok":
         db_set(chat_id, accepted=1)
-        await q.edit_message_text("Choose a chapter to drop into the running dialogue:", reply_markup=chapters_menu())
+        await q.edit_message_text("\u200b", reply_markup=chapters_menu())
         return
 
     if q.data.startswith("ch_"):
@@ -922,7 +922,7 @@ def main():
         app.job_queue.run_repeating(periodic_cleanup, interval=3600, first=3600)
     else:
         print("Job queue disabled; periodic cleanup skipped.")
-    loop.run_until_complete(app.bot.set_my_commands([("menu", "Choose a chapter")]))
+    loop.run_until_complete(app.bot.set_my_commands([("menu", "CHAPTERS"), ("start", "LETSGO")]))
     loop.run_until_complete(app.bot.set_chat_menu_button(menu_button=MenuButtonCommands()))
     print("SUPPERTIME (Assistants API) — ready.")
     webhook_url = os.getenv("WEBHOOK_URL")

--- a/tests/test_bot_flow.py
+++ b/tests/test_bot_flow.py
@@ -97,7 +97,7 @@ def test_unknown_chapter_callback(monkeypatch):
 
     monkeypatch.setattr(monolith, "ensure_thread", lambda cid: "thread-1")
 
-    update = SimpleNamespace(callback_query=make_callback_query(chat_id, chat, "ch_bad"))
+    update = SimpleNamespace(callback_query=make_callback_query(chat_id, chat, "ch_bad"), effective_chat=chat)
     context = SimpleNamespace()
     asyncio.run(monolith.on_click(update, context))
 
@@ -116,5 +116,5 @@ def test_menu_shows_chapters(monkeypatch):
     asyncio.run(monolith.menu_cmd(update, context))
     msg.reply_text.assert_awaited()
     args, kwargs = msg.reply_text.call_args
-    assert "Choose a chapter" in args[0]
+    assert args[0] == "\u200b"
     assert isinstance(kwargs.get("reply_markup"), monolith.InlineKeyboardMarkup)


### PR DESCRIPTION
## Summary
- Hide "Choose a chapter" prompt so chapter list shows without extra text
- Expose `/menu` as **CHAPTERS** and add `/start` command as **LETSGO** in menu button
- Update tests for new chapter menu behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16aaf570483299241db8ea1572af6