### PR TITLE
Replace zero-width space menu text with visible prompt

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -735,7 +735,7 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
 async def menu_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await update.message.reply_text("\u200b", reply_markup=chapters_menu())
+    await update.message.reply_text("Pick a chapter:", reply_markup=chapters_menu())
 
 async def reload_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     n = reload_chapters()
@@ -800,7 +800,7 @@ async def on_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if q.data == "ok":
         db_set(chat_id, accepted=1)
-        await q.edit_message_text("\u200b", reply_markup=chapters_menu())
+        await q.edit_message_text("Pick a chapter:", reply_markup=chapters_menu())
         return
 
     if q.data.startswith("ch_"):

--- a/tests/test_bot_flow.py
+++ b/tests/test_bot_flow.py
@@ -116,5 +116,5 @@ def test_menu_shows_chapters(monkeypatch):
     asyncio.run(monolith.menu_cmd(update, context))
     msg.reply_text.assert_awaited()
     args, kwargs = msg.reply_text.call_args
-    assert args[0] == "\u200b"
+    assert args[0] == "Pick a chapter:"
     assert isinstance(kwargs.get("reply_markup"), monolith.InlineKeyboardMarkup)


### PR DESCRIPTION
## Summary
- Avoid Telegram `BadRequest: Text must be non-empty` by replacing zero-width space replies with explicit "Pick a chapter:" text
- Update tests expecting the new chapter selection prompt

## Testing
- `pytest -q`
- `flake8 .` *(fails: command not found, dependency unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1709fccd483299198a4ce7939ec0d