### PR TITLE
Rename chapter selection prompt to 'YOU CHOOSE:'

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -735,7 +735,7 @@ async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
 async def menu_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await update.message.reply_text("Pick a chapter:", reply_markup=chapters_menu())
+    await update.message.reply_text("YOU CHOOSE:", reply_markup=chapters_menu())
 
 async def reload_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     n = reload_chapters()
@@ -800,7 +800,7 @@ async def on_click(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     if q.data == "ok":
         db_set(chat_id, accepted=1)
-        await q.edit_message_text("Pick a chapter:", reply_markup=chapters_menu())
+        await q.edit_message_text("YOU CHOOSE:", reply_markup=chapters_menu())
         return
 
     if q.data.startswith("ch_"):

--- a/tests/test_bot_flow.py
+++ b/tests/test_bot_flow.py
@@ -92,6 +92,7 @@ def test_unknown_chapter_callback(monkeypatch):
     chat_id = 4242
     chat = SimpleNamespace(id=chat_id, send_message=AsyncMock())
 
+    monolith.db_get(chat_id)  # ensure row exists
     monolith.db_set(chat_id, accepted=1, chapter=3, dialogue_n=2, last_summary="old")
     state_before = monolith.db_get(chat_id)
 
@@ -116,5 +117,5 @@ def test_menu_shows_chapters(monkeypatch):
     asyncio.run(monolith.menu_cmd(update, context))
     msg.reply_text.assert_awaited()
     args, kwargs = msg.reply_text.call_args
-    assert args[0] == "Pick a chapter:"
+    assert args[0] == "YOU CHOOSE:"
     assert isinstance(kwargs.get("reply_markup"), monolith.InlineKeyboardMarkup)


### PR DESCRIPTION
## Summary
- Say "YOU CHOOSE:" when presenting the chapter menu and after accepting the disclaimer
- Adjust bot flow tests for the new prompt and ensure test DB rows are initialized

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*

------
https://chatgpt.com/codex/tasks/task_e_68a179283a6883299c5075cb036f7aa9