### PR TITLE
Add retries and timeouts for OpenAI run operations

### DIFF
--- a/tests/test_run_and_wait.py
+++ b/tests/test_run_and_wait.py
@@ -1,0 +1,26 @@
+import os
+import asyncio
+import pytest
+from openai import APIConnectionError
+
+# Prevent network calls during import
+os.environ.setdefault("ASSISTANT_ID", "test")
+
+import monolith
+
+
+def test_run_and_wait_openai_failure(monkeypatch):
+    # avoid waiting during retries
+    async def fast_sleep(_):
+        pass
+    monkeypatch.setattr(monolith.asyncio, "sleep", fast_sleep)
+
+    def fail_create(*args, **kwargs):
+        raise APIConnectionError(request=None)
+
+    monkeypatch.setattr(monolith.client.beta.threads.runs, "create", fail_create)
+
+    with pytest.raises(RuntimeError) as exc:
+        asyncio.run(monolith.run_and_wait("thread"))
+
+    assert "network error" in str(exc.value)


### PR DESCRIPTION
## Summary
- retry OpenAI `runs.create` and `runs.retrieve` with logging and timeouts
- raise clear errors on network failures
- add test covering OpenAI refusal scenario

## Testing
- `python -m py_compile monolith.py tests/test_run_and_wait.py`
- `flake8 monolith.py tests/test_run_and_wait.py` *(fails: command not found / install blocked)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17c32c9d883299025b32931de1d17