### PR TITLE
Honor LOG_LEVEL for logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Set the following variables before running the Gospel. They are validated at sta
 - `OPENAI_TEMPERATURE` – sampling temperature (optional, defaults to `1.4`)
 - `ST_DB` – path to the SQLite database (optional)
 - `WEBHOOK_URL` – full webhook URL (optional). If set, Suppertime listens via webhook on `PORT` (default `8443`) instead of polling and clears any previous webhook on startup.
+- `LOG_LEVEL` – log level for application logging (optional, defaults to `INFO`)
 
 ## Running Locally
 1. Install dependencies: `pip install -r requirements.txt`

--- a/logger.py
+++ b/logger.py
@@ -1,5 +1,21 @@
 import logging
+import os
 
-logging.basicConfig(level=logging.INFO,
-                    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+def _get_log_level() -> int:
+    """Return the configured log level.
+
+    Reads the ``LOG_LEVEL`` environment variable and falls back to ``INFO``
+    if the variable is unset or invalid.
+    """
+
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    return getattr(logging, level_name, logging.INFO)
+
+
+logging.basicConfig(
+    level=_get_log_level(),
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
 logger = logging.getLogger("suppertimegospel")


### PR DESCRIPTION
## Summary
- make logger read `LOG_LEVEL` from environment and use it to configure `basicConfig`
- document `LOG_LEVEL` environment variable

## Testing
- `ruff check .` *(fails: unused imports and style issues in monolith.py)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a181338fd08329a0269adf8cb07728