### PR TITLE
Restore static chapter loading

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -157,13 +157,13 @@ CHAPTER_TITLES = {
 def load_chapters():
     docs: dict[int, str] = {}
     base = Path("docs")
-    for path in sorted(base.glob("chapter_*.md")):
-        match = re.match(r"chapter_(\d+)\.md", path.name)
-        if match:
-            i = int(match.group(1))
-            docs[i] = path.read_text(encoding="utf-8")
-    for i, title in CHAPTER_TITLES.items():
-        docs.setdefault(i, f"# {title}\n\n(placeholder) Provide SUPPERTIME v2.0 content here.")
+    for i in range(1, 12):
+        p = base / f"chapter_{i:02d}.md"
+        if p.exists():
+            docs[i] = p.read_text(encoding="utf-8")
+        else:
+            title = CHAPTER_TITLES.get(i, f"Chapter {i}")
+            docs[i] = f"# {title}\n\n(placeholder) Provide SUPPERTIME v2.0 content here."
     return docs
 
 CHAPTERS = load_chapters()
@@ -416,8 +416,8 @@ DISCLAIMER = (
 
 def chapters_menu():
     kb = [
-        [InlineKeyboardButton(CHAPTER_TITLES.get(i, f"Chapter {i}"), callback_data=f"ch_{i}")]
-        for i in sorted(CHAPTERS)
+        [InlineKeyboardButton(CHAPTER_TITLES[i], callback_data=f"ch_{i}")]
+        for i in range(1, 12)
     ]
     return InlineKeyboardMarkup(kb)
 


### PR DESCRIPTION
## Summary
- Revert dynamic glob-based chapter loading to a fixed list ensuring chapters always load correctly.
- Reinstate static chapter menu construction matching predefined chapter titles.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1869e9a408329878fb061d65f150e