### PR TITLE
Handle colon dialogue lines in parse_lines

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -918,18 +918,27 @@ async def reload_heroes_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
 def parse_lines(text: str):
     name_line = re.compile(r"^\*{1,2}(.+?)\*{1,2}$")
     inline = re.compile(r"^\*{1,2}(.+?)\*{1,2}:\s*(.*)")
+    plain_inline = re.compile(r"^(?!\*{1,2})([^:]+?):\s*(.*)")
     current_name = None
     buffer: list[str] = []
     for raw in text.splitlines():
         line = raw.rstrip()
-        m_inline = inline.match(line.strip())
+        stripped = line.strip()
+        m_inline = inline.match(stripped)
         if m_inline:
             if current_name and buffer:
                 yield current_name, "\n".join(buffer).strip()
             yield m_inline.group(1), m_inline.group(2)
             current_name, buffer = None, []
             continue
-        m_name = name_line.match(line.strip())
+        m_plain = plain_inline.match(stripped)
+        if m_plain:
+            if current_name and buffer:
+                yield current_name, "\n".join(buffer).strip()
+            yield m_plain.group(1), m_plain.group(2)
+            current_name, buffer = None, []
+            continue
+        m_name = name_line.match(stripped)
         if m_name:
             if current_name and buffer:
                 yield current_name, "\n".join(buffer).strip()

--- a/tests/test_monolith.py
+++ b/tests/test_monolith.py
@@ -56,6 +56,32 @@ def test_parse_lines_block_format():
     ]
 
 
+def test_parse_lines_plain_inline():
+    text = (
+        "Judas: betrayal whispers\n"
+        "Peter: steadfast response"
+    )
+    assert list(parse_lines(text)) == [
+        ("Judas", "betrayal whispers"),
+        ("Peter", "steadfast response"),
+    ]
+
+
+def test_parse_lines_mixed_format():
+    text = (
+        "*Judas*\n"
+        "betrayal whispers\n"
+        "Peter: steadfast response\n"
+        "*Mary*\n"
+        "quiet"
+    )
+    assert list(parse_lines(text)) == [
+        ("Judas", "betrayal whispers"),
+        ("Peter", "steadfast response"),
+        ("Mary", "quiet"),
+    ]
+
+
 def test_main_checks_env(monkeypatch):
     import monolith
 


### PR DESCRIPTION
## Summary
- support unstarred `Name: text` dialogue lines in `parse_lines`
- test plain and mixed dialogue formats

## Testing
- `pytest -q`
- `flake8 .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a491285fec83298ff2096c6efc8a13