### PR TITLE
Keep typing indicator active

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -967,8 +967,13 @@ async def send_hero_lines(
     sent = False
     for name, line in parse_lines(text):
         typing = await chat.send_message(f"{name} is typing…")
-        await context.bot.send_chat_action(chat.id, ChatAction.TYPING)
-        await asyncio.sleep(random.uniform(3, 5))
+        delay = random.uniform(3, 5)
+        elapsed = 0.0
+        while elapsed < delay:
+            await context.bot.send_chat_action(chat.id, ChatAction.TYPING)
+            step = min(4, delay - elapsed)
+            await asyncio.sleep(step)
+            elapsed += step
         await typing.delete()
         header = f"**{name}**"
         await chat.send_message(

--- a/tests/test_bot_flow.py
+++ b/tests/test_bot_flow.py
@@ -282,6 +282,7 @@ def test_send_hero_lines_reply_to(monkeypatch):
     calls = chat.send_message.await_args_list
     assert len(calls) == 2
     assert calls[1].kwargs["reply_to_message_id"] == 77
+    typing_msg.delete.assert_awaited_once()
 
 
 def test_send_hero_lines_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- Refresh typing action in a loop before sending hero lines
- Remove temporary "is typing" message after each cycle
- Test that the typing placeholder is cleaned up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a496474bf88329a49c1713f7d3e764