### PR TITLE
Maintain typing indicator during hero lines

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -966,7 +966,7 @@ async def send_hero_lines(
         elapsed = 0.0
         while elapsed < delay:
             await context.bot.send_chat_action(chat.id, ChatAction.TYPING)
-            step = min(4, delay - elapsed)
+            step = min(1, delay - elapsed)
             await asyncio.sleep(step)
             elapsed += step
         await typing.delete()

--- a/tests/test_send_hero_lines.py
+++ b/tests/test_send_hero_lines.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+import random
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+# Prevent network calls during import
+os.environ.setdefault("ASSISTANT_ID", "test")
+
+from monolith import send_hero_lines
+
+
+def test_send_chat_action_multiple_calls(monkeypatch):
+    chat = MagicMock()
+    chat.id = 1
+    typing_msg = MagicMock()
+    typing_msg.delete = AsyncMock()
+    final_msg = MagicMock()
+    chat.send_message = AsyncMock(side_effect=[typing_msg, final_msg])
+
+    context = MagicMock()
+    context.bot = MagicMock()
+    context.bot.send_chat_action = AsyncMock()
+
+    monkeypatch.setattr(random, "uniform", lambda a, b: 3)
+
+    async def fast_sleep(_):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    asyncio.run(send_hero_lines(chat, "*Judas*\nhello", context))
+
+    assert context.bot.send_chat_action.await_count > 1


### PR DESCRIPTION
## Summary
- Reduce typing indicator loop delay to 1 second so `send_chat_action` refreshes frequently
- Add unit test verifying multiple `send_chat_action` calls while waiting

## Testing
- `python -m py_compile monolith.py tests/test_send_hero_lines.py`
- `pytest tests/test_send_hero_lines.py`


------
https://chatgpt.com/codex/tasks/task_e_68a49f628048832981b3dc95da68c109