### PR TITLE
Expand dialogue parsing formats

### DIFF
--- a/monolith.py
+++ b/monolith.py
@@ -925,27 +925,41 @@ async def reload_heroes_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 def parse_lines(text: str):
     sep = r"[:\-\–—]"
-    name_line_star = re.compile(r"^\*{1,2}\s*(.+?)\s*\*{1,2}$")
-    name_line_heading = re.compile(r"^\s{0,3}#{1,6}\s*(.+?)\s*#*\s*$")
-    inline_star = re.compile(rf"^\*{{1,2}}\s*(.+?)\s*\*{{1,2}}\s*{sep}\s*(.*)")
-    inline_plain = re.compile(rf"^(?!\*{{1,2}})(.+?)\s*{sep}\s*(.*)")
+    bullet = r"(?:[-*+•]\s*)?"
+    name_line_star = re.compile(rf"^{bullet}\*{{1,2}}\s*(.+?)\s*\*{{1,2}}$")
+    name_line_heading = re.compile(rf"^\s{{0,3}}{bullet}#{{1,6}}\s*(.+?)\s*#*\s*$")
+    inline_star = re.compile(
+        rf"^{bullet}\*{{1,2}}\s*(.+?)\s*\*{{1,2}}\s*{sep}\s*(.*)"
+    )
+    inline_plain = re.compile(rf"^{bullet}(?!\*{{1,2}})(.+?)\s*{sep}\s*(.*)")
+    inline_says = re.compile(
+        rf"^{bullet}(?!\*{{1,2}})(.+?)\s+says\s*(?:{sep}\s*)?(.*)", re.I
+    )
+
+    def normalize(name: str) -> str:
+        return name.strip(" \"'“”‘’*-—–•")
+
     current_name = None
     buffer: list[str] = []
     for raw in text.splitlines():
         line = raw.rstrip()
-        stripped = line.strip()
-        m_inline = inline_star.match(stripped) or inline_plain.match(stripped)
+        stripped = line.strip().strip("\"'“”‘’")
+        m_inline = (
+            inline_star.match(stripped)
+            or inline_says.match(stripped)
+            or inline_plain.match(stripped)
+        )
         if m_inline:
             if current_name and buffer:
                 yield current_name, "\n".join(buffer).strip()
-            yield m_inline.group(1).strip(), m_inline.group(2)
+            yield normalize(m_inline.group(1)), m_inline.group(2)
             current_name, buffer = None, []
             continue
         m_name = name_line_star.match(stripped) or name_line_heading.match(stripped)
         if m_name:
             if current_name and buffer:
                 yield current_name, "\n".join(buffer).strip()
-            current_name = m_name.group(1).strip()
+            current_name = normalize(m_name.group(1))
             buffer = []
         elif current_name is not None:
             buffer.append(line)

--- a/tests/test_parse_lines.py
+++ b/tests/test_parse_lines.py
@@ -33,3 +33,17 @@ def test_parse_lines_markdown_heading_block():
     text = ("# Judas\n" "first\n" "## Mary  ##\n" "second")
     assert list(parse_lines(text)) == [("Judas", "first"), ("Mary", "second")]
 
+
+def test_parse_lines_name_says_variants():
+    text = "Judas says hello\nMary says: bye"
+    assert list(parse_lines(text)) == [("Judas", "hello"), ("Mary", "bye")]
+
+
+def test_parse_lines_bullet_markers_and_quotes():
+    text = "- 'Judas': hi\n* \"Mary\" — bye\n• Peter says greetings"
+    assert list(parse_lines(text)) == [
+        ("Judas", "hi"),
+        ("Mary", "bye"),
+        ("Peter", "greetings"),
+    ]
+


### PR DESCRIPTION
## Summary
- broaden `parse_lines` to handle list markers, quotes, and "Name says" patterns
- normalize speaker names by trimming punctuation
- add unit tests covering bullets, quoted names, and "says" variants

## Testing
- ❌ `python -m pytest` (failing tests: `test_send_hero_lines_delay_and_separate`, `test_chapter_callback_send_error`)
- ✅ `python -m pytest tests/test_parse_lines.py`
- ✅ `python -m py_compile monolith.py tests/test_parse_lines.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0db33488329a04f4cbb79a0f6fc