### PR TITLE
Expand parsing and fallback test coverage

### DIFF
--- a/tests/test_parse_lines.py
+++ b/tests/test_parse_lines.py
@@ -47,3 +47,15 @@ def test_parse_lines_bullet_markers_and_quotes():
         ("Peter", "greetings"),
     ]
 
+
+def test_parse_lines_name_with_spaces_and_quoted_answer():
+    text = '**Mary Magdalene**: She said "Hello" loudly'
+    assert list(parse_lines(text)) == [
+        ("Mary Magdalene", 'She said "Hello" loudly')
+    ]
+
+
+def test_parse_lines_list_marker_with_space_in_name():
+    text = "- Mary Magdalene says hello"
+    assert list(parse_lines(text)) == [("Mary Magdalene", "hello")]
+

--- a/tests/test_send_hero_lines.py
+++ b/tests/test_send_hero_lines.py
@@ -71,3 +71,35 @@ def test_partial_unrecognized_fallback(monkeypatch, caplog):
         reply_to_message_id=None,
     )
     assert "Expected 2 lines" in caplog.text
+
+
+def test_quote_line_unrecognized(monkeypatch, caplog):
+    chat = MagicMock(id=1, send_message=AsyncMock())
+    context = MagicMock(bot=MagicMock(send_chat_action=AsyncMock()))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    text = '"Judas" hi'
+    with caplog.at_level("WARNING"):
+        asyncio.run(send_hero_lines(chat, text, context, participants=["Judas"]))
+    chat.send_message.assert_awaited_once_with(
+        f"**Narrator**\n{text}",
+        parse_mode=ParseMode.MARKDOWN,
+        reply_to_message_id=None,
+    )
+    assert "Expected 1 lines" in caplog.text
+
+
+def test_list_marker_unrecognized(monkeypatch, caplog):
+    chat = MagicMock(id=1, send_message=AsyncMock())
+    context = MagicMock(bot=MagicMock(send_chat_action=AsyncMock()))
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    text = "- Judas hi"
+    with caplog.at_level("WARNING"):
+        asyncio.run(send_hero_lines(chat, text, context, participants=["Judas"]))
+    chat.send_message.assert_awaited_once_with(
+        f"**Narrator**\n{text}",
+        parse_mode=ParseMode.MARKDOWN,
+        reply_to_message_id=None,
+    )
+    assert "Expected 1 lines" in caplog.text


### PR DESCRIPTION
## Summary
- test parsing with names containing spaces, quotes, and list markers
- ensure send_hero_lines falls back when responses can't be parsed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4bee3085c8329a02d4338dec56d92