### PR TITLE
Refactor runtime initialization

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -752,9 +752,12 @@ def main():
         raise RuntimeError("Set TELEGRAM_TOKEN env var")
     if not settings.openai_api_key:
         raise RuntimeError("Set OPENAI_API_KEY env var")
-    asyncio.run(db_init())
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
+    loop.run_until_complete(db_init())
+    from theatre import reload_heroes
+
+    reload_heroes()
     loop.run_until_complete(reset_updates())
     app = Application.builder().token(TELEGRAM_TOKEN).build()
     app.add_handler(CommandHandler("start", start))

--- a/db.py
+++ b/db.py
@@ -79,4 +79,3 @@ async def db_set(chat_id, **fields):
         logger.exception("DB set failed for chat_id %s: %s", chat_id, e)
 
 
-asyncio.run(db_init())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import asyncio
+import pytest
+
+from db import db_init
+from theatre import reload_heroes
+
+
+@pytest.fixture(scope="session", autouse=True)
+def init_runtime():
+    asyncio.run(db_init())
+    reload_heroes()

--- a/tests/test_bot_flow.py
+++ b/tests/test_bot_flow.py
@@ -453,6 +453,7 @@ def test_chapter_callback_send_error(monkeypatch):
         chat_id = 555
         chat = SimpleNamespace(id=chat_id, send_message=AsyncMock())
 
+        await db_get(chat_id)  # ensure row exists
         await db_set(chat_id, accepted=1, chapter=None, dialogue_n=0, last_summary="")
 
         monkeypatch.setattr(bridge, "ensure_thread", AsyncMock(return_value="thread-1"))

--- a/theatre.py
+++ b/theatre.py
@@ -203,11 +203,6 @@ def reload_heroes():
             p.unlink()
     return load_heroes()
 
-
-# Load heroes at import
-load_heroes()
-
-
 async def load_chapter_context_all(md_text: str, names: list[str]):
     """Notify selected heroes about the chosen chapter in the background."""
     md_hash = hashlib.sha1(md_text.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## Summary
- remove side-effectful initialization from modules
- initialize database and heroes in bridge.main
- ensure tests set up database and hero cache explicitly

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a4df2661a08329ac99ff2819200a56