### PR TITLE
feat: centralize hero management

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -578,9 +578,9 @@ async def reload_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def reload_heroes_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    from theatre import reload_heroes  # local import to avoid circular
+    from theatre import hero_manager  # local import to avoid circular
 
-    n = reload_heroes()
+    n = hero_manager.reload()
     st = await db_get(update.effective_chat.id)
     if st.get("chapter"):
         chapter_text = CHAPTERS[st["chapter"]]
@@ -755,9 +755,9 @@ def main():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     loop.run_until_complete(db_init())
-    from theatre import reload_heroes
+    from theatre import hero_manager
 
-    reload_heroes()
+    hero_manager.reload()
     loop.run_until_complete(reset_updates())
     app = Application.builder().token(TELEGRAM_TOKEN).build()
     app.add_handler(CommandHandler("start", start))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@ import asyncio
 import pytest
 
 from db import db_init
-from theatre import reload_heroes
+from theatre import hero_manager
 
 
 @pytest.fixture(scope="session", autouse=True)
 def init_runtime():
     asyncio.run(db_init())
-    reload_heroes()
+    hero_manager.reload()


### PR DESCRIPTION
## Summary
- introduce `HeroManager` for loading heroes and caching contexts
- swap global hero dictionaries for `hero_manager` singleton
- update bot commands and tests to use `hero_manager`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e1d5cb14832980d6c26f98c6bb69