### PR TITLE
Refactor logging to use settings

### DIFF
--- a/bridge.py
+++ b/bridge.py
@@ -5,8 +5,9 @@ import contextlib
 import time
 import os
 from pathlib import Path
+import logging
+import logger
 
-from logger import logger
 from config import settings
 
 from telegram import (
@@ -45,6 +46,8 @@ from db import db_get, db_set, db_init, SUMMARY_EVERY
 MODEL = settings.openai_model
 TEMPERATURE = settings.openai_temperature
 TELEGRAM_TOKEN = settings.telegram_token
+
+logger = logging.getLogger(__name__)
 
 OPENAI_TIMEOUT = 30
 OPENAI_RETRY_ATTEMPTS = 3

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import os
+import logging
 
 from dotenv import load_dotenv
 
@@ -23,6 +24,34 @@ class Settings:
     assistant_id: str | None = os.getenv("ASSISTANT_ID")
     hero_ctx_cache_dir: Path = Path(os.getenv("HERO_CTX_CACHE_DIR", ".hero_ctx_cache"))
     chaos_cleanup_max_age_hours: int = int(os.getenv("CHAOS_CLEANUP_MAX_AGE_HOURS", "24"))
+
+    def validate(self) -> None:
+        """Ensure all required settings are present.
+
+        Currently ``telegram_token`` and ``openai_api_key`` are mandatory for
+        the application to run. A :class:`RuntimeError` is raised if any of
+        these values are missing.
+        """
+
+        required = {
+            "telegram_token": self.telegram_token,
+            "openai_api_key": self.openai_api_key,
+        }
+        missing = [name for name, value in required.items() if not value]
+        if missing:
+            raise RuntimeError(
+                "Missing required environment variables: " + ", ".join(missing)
+            )
+
+    def get_log_level(self) -> int:
+        """Return the configured logging level.
+
+        Reads ``LOG_LEVEL`` from the environment and falls back to ``INFO``
+        when the variable is unset or invalid.
+        """
+
+        level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+        return getattr(logging, level_name, logging.INFO)
 
 
 settings = Settings()

--- a/db.py
+++ b/db.py
@@ -1,8 +1,11 @@
 import asyncio
 import aiosqlite
+import logging
+import logger
 
-from logger import logger
 from config import settings
+
+logger = logging.getLogger(__name__)
 
 DB_PATH = settings.db_path
 SUMMARY_EVERY = settings.summary_every

--- a/logger.py
+++ b/logger.py
@@ -1,21 +1,10 @@
 import logging
-import os
 
-
-def _get_log_level() -> int:
-    """Return the configured log level.
-
-    Reads the ``LOG_LEVEL`` environment variable and falls back to ``INFO``
-    if the variable is unset or invalid.
-    """
-
-    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
-    return getattr(logging, level_name, logging.INFO)
+from config import settings
 
 
 logging.basicConfig(
-    level=_get_log_level(),
+    level=settings.get_log_level(),
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 
-logger = logging.getLogger("suppertimegospel")

--- a/theatre.py
+++ b/theatre.py
@@ -7,9 +7,10 @@ import time
 import contextlib
 from collections import defaultdict
 from pathlib import Path
+import logging
+import logger
 
 from config import settings
-from logger import logger
 
 try:
     from openai import (
@@ -25,6 +26,8 @@ except ImportError as e:
 
 MODEL = settings.openai_model
 TEMPERATURE = settings.openai_temperature
+
+logger = logging.getLogger(__name__)
 
 client = OpenAI()
 


### PR DESCRIPTION
## Summary
- add Settings.validate and Settings.get_log_level helpers
- configure logging via settings and use module-level loggers
- update modules to fetch loggers with `logging.getLogger(__name__)`

## Testing
- `python -m py_compile config.py logger.py bridge.py db.py theatre.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ec5536c0832994b802b88b139e52