### PR TITLE
Add tests for hero caching, DB error handling, and Markov glitches

### DIFF
--- a/tests/test_db_error_handling.py
+++ b/tests/test_db_error_handling.py
@@ -1,0 +1,67 @@
+import asyncio
+import logging
+import sqlite3
+
+import bridge
+import db
+
+
+def test_db_get_returns_default_on_error(monkeypatch, caplog):
+    def fake_connect(*a, **k):  # pragma: no cover - stub
+        raise db.aiosqlite.Error("boom")
+
+    monkeypatch.setattr(db.aiosqlite, "connect", fake_connect)
+    with caplog.at_level(logging.ERROR):
+        state = asyncio.run(db.db_get(123))
+    assert state == {
+        "chat_id": 123,
+        "thread_id": None,
+        "accepted": False,
+        "chapter": None,
+        "dialogue_n": 0,
+        "last_summary": "",
+    }
+    assert "DB get failed for chat_id 123" in caplog.text
+
+
+def test_cleanup_threads_logs_sqlite_error(monkeypatch, caplog):
+    rows = [{"chat_id": 1, "thread_id": "tid"}]
+
+    class DummyCursor:
+        def fetchall(self):
+            return rows
+
+    class DummyConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def execute(self, *a, **k):
+            return DummyCursor()
+
+    import sqlite3 as sqlite3_module
+
+    monkeypatch.setattr(sqlite3_module, "connect", lambda path: DummyConn())
+
+    class DummyThreads:
+        def delete(self, tid):
+            pass
+
+    class DummyClient:
+        class Beta:
+            threads = DummyThreads()
+
+        beta = Beta()
+
+    monkeypatch.setattr(bridge, "client", DummyClient())
+
+    async def fake_db_set(*a, **k):  # pragma: no cover - stub
+        raise sqlite3.Error("fail")
+
+    monkeypatch.setattr(bridge, "db_set", fake_db_set)
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(bridge.cleanup_threads())
+    assert "Failed to delete thread tid" in caplog.text

--- a/tests/test_hero_context_cache.py
+++ b/tests/test_hero_context_cache.py
@@ -1,0 +1,59 @@
+import asyncio
+import theatre
+
+
+def test_load_chapter_context_uses_memory_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(theatre.hero_manager, "cache_dir", tmp_path)
+    theatre.hero_manager.ctx_cache.clear()
+    theatre.hero_manager.ctx_cache[("Tester", "hash")] = "ctx"
+
+    hero = theatre.Hero("Tester", {"INIT": "hi"}, "raw")
+
+    def fake_create(*a, **k):
+        raise AssertionError("API should not be called on cache hit")
+
+    monkeypatch.setattr(theatre.client.responses, "create", fake_create)
+
+    asyncio.run(hero.load_chapter_context("md", "hash"))
+    assert hero.ctx == "ctx"
+
+
+def test_load_chapter_context_reads_cache_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(theatre.hero_manager, "cache_dir", tmp_path)
+    theatre.hero_manager.ctx_cache.clear()
+    cache_file = tmp_path / "Tester_hash.txt"
+    cache_file.write_text("filectx", encoding="utf-8")
+
+    hero = theatre.Hero("Tester", {"INIT": "hi"}, "raw")
+
+    def fake_create(*a, **k):
+        raise AssertionError("API should not be called when file cache exists")
+
+    monkeypatch.setattr(theatre.client.responses, "create", fake_create)
+
+    asyncio.run(hero.load_chapter_context("md", "hash"))
+    assert hero.ctx == "filectx"
+    assert theatre.hero_manager.ctx_cache[("Tester", "hash")] == "filectx"
+
+
+def test_load_chapter_context_calls_api_when_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(theatre.hero_manager, "cache_dir", tmp_path)
+    theatre.hero_manager.ctx_cache.clear()
+
+    class Resp:
+        output_text = "apictx"
+
+    calls = {"n": 0}
+
+    def fake_create(*a, **k):
+        calls["n"] += 1
+        return Resp()
+
+    monkeypatch.setattr(theatre.client.responses, "create", fake_create)
+
+    hero = theatre.Hero("Tester", {"INIT": "hi"}, "raw")
+    asyncio.run(hero.load_chapter_context("md", "hash"))
+    assert hero.ctx == "apictx"
+    assert calls["n"] == 1
+    assert (tmp_path / "Tester_hash.txt").read_text(encoding="utf-8") == "apictx"
+    assert theatre.hero_manager.ctx_cache[("Tester", "hash")] == "apictx"

--- a/tests/test_markov_engine.py
+++ b/tests/test_markov_engine.py
@@ -1,0 +1,16 @@
+import theatre
+
+
+def test_markov_glitch_generates_text(monkeypatch):
+    engine = theatre.MarkovEngine()
+    engine.p = 1.0
+    monkeypatch.setattr(theatre.random, "random", lambda: 0.0)
+    monkeypatch.setattr(theatre.random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(theatre.random, "randint", lambda a, b: 2)
+    assert engine.glitch() == "*WHO ARE YOU*"
+
+
+def test_markov_glitch_none_when_probability_low():
+    engine = theatre.MarkovEngine()
+    engine.p = 0.0
+    assert engine.glitch() is None


### PR DESCRIPTION
## Summary
- add tests for Hero.load_chapter_context covering in-memory cache hits, on-disk cache hits, and API misses
- ensure database helpers log and return defaults on sqlite3/aiosqlite failures
- exercise MarkovEngine.glitch with deterministic output

## Testing
- `flake8` *(fails: command not found; attempted install but network 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4f3cdeea48329bd110b1b4599c6d6